### PR TITLE
Refactor swatch generation logic and enhance documentation

### DIFF
--- a/Source/UniversalSwatchSlots/Private/UniversalSwatchSlotsGIModule.cpp
+++ b/Source/UniversalSwatchSlots/Private/UniversalSwatchSlotsGIModule.cpp
@@ -45,7 +45,14 @@ void UUniversalSwatchSlotsGIModule::GenerateDynamicSwatchClasses()
 	for (int32 i = startID; i < maxSlots; i++)
 	{
 		this->GenerateDynamicSwatchDescriptor(i);
-		this->GenerateDynamicSwatchRecipe(i);
+		// Do NOT eagerly generate 200+ customization recipe classes.
+		// Those UFGCustomizationRecipe subclasses can end up in AFGRecipeManager::mAvailableCustomizationRecipes
+		// (SaveGame + Replicated) and cause ReliableBufferOverflow during join/load.
+		//
+		// Swatch *descriptors* are what buildings reference in FFactoryCustomizationData.SwatchDesc.
+		// Keeping descriptors ensures saves load, while skipping recipe generation prevents recipe-manager replication bloat.
+		//
+		// If recipes are needed for UI, generate them lazily only for used swatches.
 	}
 }
 

--- a/Source/UniversalSwatchSlots/Private/UniversalSwatchSlotsGIModule.cpp
+++ b/Source/UniversalSwatchSlots/Private/UniversalSwatchSlotsGIModule.cpp
@@ -45,14 +45,7 @@ void UUniversalSwatchSlotsGIModule::GenerateDynamicSwatchClasses()
 	for (int32 i = startID; i < maxSlots; i++)
 	{
 		this->GenerateDynamicSwatchDescriptor(i);
-		// Do NOT eagerly generate 200+ customization recipe classes.
-		// Those UFGCustomizationRecipe subclasses can end up in AFGRecipeManager::mAvailableCustomizationRecipes
-		// (SaveGame + Replicated) and cause ReliableBufferOverflow during join/load.
-		//
-		// Swatch *descriptors* are what buildings reference in FFactoryCustomizationData.SwatchDesc.
-		// Keeping descriptors ensures saves load, while skipping recipe generation prevents recipe-manager replication bloat.
-		//
-		// If recipes are needed for UI, generate them lazily only for used swatches.
+		// Skip recipe generation to prevent ReliableBufferOverflow replication bloat; descriptors alone are sufficient for save compatibility.
 	}
 }
 

--- a/Source/UniversalSwatchSlots/Private/UniversalSwatchSlotsSubsystem.cpp
+++ b/Source/UniversalSwatchSlots/Private/UniversalSwatchSlotsSubsystem.cpp
@@ -304,10 +304,9 @@ bool AUniversalSwatchSlotsSubsystem::GenerateNewSwatchUsingInfo(UUSSSwatchGroup*
 {
 	int32 slotID = this->ValidSlotIDs[0];
 
-	// Avoid generating customization *recipes* for swatches (see GI module note).
-	if (this->SwatchDescriptorArray.Contains(slotID))
-	{	// We can't overwrite existing swatch. (Well we could but I don't want to in order to not mess up evrything)
-
+	// We can't overwrite existing swatch. (Well we could but I don't want to in order to not mess up evrything)
+	if (this->SwatchDescriptorArray.Contains(slotID) || this->SwatchRecipeArray.Contains(slotID))
+	{
 		return false;
 	}
 
@@ -343,9 +342,13 @@ bool AUniversalSwatchSlotsSubsystem::GenerateNewSwatchUsingInfo(UUSSSwatchGroup*
 		this->InternalSwatchMatch.Add(slotID, slotID);
 	}
 
-	this->GenerateDynamicSwatchDescriptor(slotID, genName, SwatchGroup, SwatchInfo);
+	UUSSSwatchDesc* SwatchDescriptor = this->GenerateDynamicSwatchDescriptor(slotID, genName, SwatchGroup, SwatchInfo);
 
 	this->ValidSlotIDs.RemoveAt(0);
+
+	// Generate a customization recipe only for swatches that actually exist (i.e. palette-defined),
+	// so they show up in the customizer, without generating hundreds at startup.
+	this->GenerateDynamicSwatchRecipe(slotID, SwatchDescriptor);
 
 	return true;
 }

--- a/Source/UniversalSwatchSlots/Private/UniversalSwatchSlotsSubsystem.cpp
+++ b/Source/UniversalSwatchSlots/Private/UniversalSwatchSlotsSubsystem.cpp
@@ -346,8 +346,6 @@ bool AUniversalSwatchSlotsSubsystem::GenerateNewSwatchUsingInfo(UUSSSwatchGroup*
 
 	this->ValidSlotIDs.RemoveAt(0);
 
-	// Generate a customization recipe only for swatches that actually exist (i.e. palette-defined),
-	// so they show up in the customizer, without generating hundreds at startup.
 	this->GenerateDynamicSwatchRecipe(slotID, SwatchDescriptor);
 
 	return true;

--- a/Source/UniversalSwatchSlots/Private/UniversalSwatchSlotsSubsystem.cpp
+++ b/Source/UniversalSwatchSlots/Private/UniversalSwatchSlotsSubsystem.cpp
@@ -40,54 +40,62 @@ AUniversalSwatchSlotsSubsystem* AUniversalSwatchSlotsSubsystem::Get(UObject* Wor
 void AUniversalSwatchSlotsSubsystem::AddNewSwatchesColorSlotsToGameState(TArray<UUSSSwatchDesc*> SwatchDescriptions)
 {
 	AFGGameState* FGGameState = Cast<AFGGameState>(UGameplayStatics::GetGameState(this));
-
-	if (FGGameState)
+	if (!FGGameState)
 	{
+		return;
+	}
 
-		for (UUSSSwatchDesc* Swatch : SwatchDescriptions)
-		{	// Browse all the swatch descriptions
+	// Slot data is replicated from the server via AFGGameState.
+	// Calling Server_SetBuildingColorDataForSlot in a loop (Reliable RPC) can easily overflow the reliable buffer during join.
+	if (!HasAuthority())
+	{
+		UE_LOG(LogUSS_Subsystem, Verbose, TEXT("AddNewSwatchesColorSlotsToGameState called on client; skipping."));
+		return;
+	}
 
-			if (Swatch)
+	bool bAnyChanged = false;
+
+	for (UUSSSwatchDesc* Swatch : SwatchDescriptions)
+	{	// Browse all the swatch descriptions
+		if (!Swatch)
+		{
+			continue;
+		}
+
+		const int32 ColourIndex = Swatch->ID;
+
+		FFactoryCustomizationColorSlot NewColourSlot = FFactoryCustomizationColorSlot(FLinearColor::Black, FLinearColor::Black);
+		NewColourSlot.PaintFinish = this->PaintFinishes[(uint8)Swatch->Material];
+
+		if (FGGameState->mBuildingColorSlots_Data.Num() <= ColourIndex)
+		{	// Ensure the slot array is large enough
+			for (int32 i = FGGameState->mBuildingColorSlots_Data.Num(); i <= ColourIndex; ++i)
 			{
-				int32 ColourIndex = Swatch->ID;
-
-				FFactoryCustomizationColorSlot NewColourSlot = FFactoryCustomizationColorSlot(FLinearColor::Black, FLinearColor::Black);
-				NewColourSlot.PaintFinish = this->PaintFinishes[(uint8)Swatch->Material];
-
-				if (FGGameState->mBuildingColorSlots_Data.Num() <= ColourIndex)
-				{	// We need to create some default swatch slots
-
-					for (int32 i = FGGameState->mBuildingColorSlots_Data.Num(); i <= ColourIndex; ++i)
-					{
-						if (!FGGameState->mBuildingColorSlots_Data.IsValidIndex(i))
-						{	// We need to add a new slot
-
-							FGGameState->mBuildingColorSlots_Data.Add(NewColourSlot);
-							UE_LOG(LogUSS_Subsystem, Verbose, TEXT("New color slot added to gamestate: %d"), i);
-						}
-					}
-				}
-
-				// Changes the colour to the desired one
-				NewColourSlot.PrimaryColor = Swatch->PrimaryColour;
-				NewColourSlot.SecondaryColor = Swatch->SecondaryColour;
-
-				// Update the subsystem and game state 
-				FGGameState->mBuildingColorSlots_Data[ColourIndex] = NewColourSlot;
+				FGGameState->mBuildingColorSlots_Data.Add(NewColourSlot);
+				UE_LOG(LogUSS_Subsystem, Verbose, TEXT("New color slot added to gamestate: %d"), i);
+				bAnyChanged = true;
 			}
 		}
 
-		TArray<FFactoryCustomizationColorSlot> ColorSlots = FGGameState->mBuildingColorSlots_Data;
-		FGGameState->SetupColorSlots_Data(ColorSlots);
+		// Apply desired colors
+		NewColourSlot.PrimaryColor = Swatch->PrimaryColour;
+		NewColourSlot.SecondaryColor = Swatch->SecondaryColour;
 
-		for (int32 i = 0; i < ColorSlots.Num(); i++)
-		{	// Update buildings
-
-			FFactoryCustomizationColorSlot ColorSlot = ColorSlots[i];
-			FGGameState->Server_SetBuildingColorDataForSlot(i, ColorSlot);
+		if (FGGameState->mBuildingColorSlots_Data.IsValidIndex(ColourIndex))
+		{
+			const FFactoryCustomizationColorSlot& Existing = FGGameState->mBuildingColorSlots_Data[ColourIndex];
+			if (Existing.PrimaryColor != NewColourSlot.PrimaryColor || Existing.SecondaryColor != NewColourSlot.SecondaryColor || Existing.PaintFinish != NewColourSlot.PaintFinish)
+			{
+				FGGameState->mBuildingColorSlots_Data[ColourIndex] = NewColourSlot;
+				bAnyChanged = true;
+			}
 		}
+	}
 
-		return;
+	if (bAnyChanged)
+	{
+		// Let GameState apply / refresh any internal state using the current slots.
+		FGGameState->SetupColorSlots_Data(FGGameState->mBuildingColorSlots_Data);
 	}
 }
 
@@ -296,7 +304,8 @@ bool AUniversalSwatchSlotsSubsystem::GenerateNewSwatchUsingInfo(UUSSSwatchGroup*
 {
 	int32 slotID = this->ValidSlotIDs[0];
 
-	if (this->SwatchDescriptorArray.Contains(slotID) || this->SwatchRecipeArray.Contains(slotID))
+	// Avoid generating customization *recipes* for swatches (see GI module note).
+	if (this->SwatchDescriptorArray.Contains(slotID))
 	{	// We can't overwrite existing swatch. (Well we could but I don't want to in order to not mess up evrything)
 
 		return false;
@@ -334,11 +343,9 @@ bool AUniversalSwatchSlotsSubsystem::GenerateNewSwatchUsingInfo(UUSSSwatchGroup*
 		this->InternalSwatchMatch.Add(slotID, slotID);
 	}
 
-	UUSSSwatchDesc* SwatchDescriptor = this->GenerateDynamicSwatchDescriptor(slotID, genName, SwatchGroup, SwatchInfo);
+	this->GenerateDynamicSwatchDescriptor(slotID, genName, SwatchGroup, SwatchInfo);
 
 	this->ValidSlotIDs.RemoveAt(0);
-
-	UUSSSwatchRecipe* SwatchRecipe = this->GenerateDynamicSwatchRecipe(slotID, SwatchDescriptor);
 
 	return true;
 }

--- a/Source/UniversalSwatchSlots/Public/UniversalSwatchSlotsGIModule.h
+++ b/Source/UniversalSwatchSlots/Public/UniversalSwatchSlotsGIModule.h
@@ -54,7 +54,7 @@ class UNIVERSALSWATCHSLOTS_API UUniversalSwatchSlotsGIModule : public UGameInsta
 	/**
 	 * Create a new swatch using the desired group ID and swatch name.
 	 *
-	 * Note: This function will create a new swatch group if the given group ID doensn't exist in the SwatchGroupArray and call GenerateDynamicSwatchGroup -> GenerateDynamicSwatchDescriptor -> GenerateDynamicSwatchRecipe functions. This function does nothing if the swatch descriptor / recipe already exist.
+	 * Note: This function will create a new swatch group if the given group ID doensn't exist in the SwatchGroupArray and call GenerateDynamicSwatchGroup -> GenerateDynamicSwatchDescriptor functions. This function does nothing if the swatch descriptor already exist.
 	 *
 	 * @param	UniqueGroupID				The swatch group ID to use. If the group doesn't exist it will be created.
 	 * @param	GroupDisplayName			The name to give to the swatch group. If the group already exist its name will be changed.

--- a/Source/UniversalSwatchSlots/Public/UniversalSwatchSlotsGIModule.h
+++ b/Source/UniversalSwatchSlots/Public/UniversalSwatchSlotsGIModule.h
@@ -54,8 +54,7 @@ class UNIVERSALSWATCHSLOTS_API UUniversalSwatchSlotsGIModule : public UGameInsta
 	/**
 	 * Create a new swatch using the desired group ID and swatch name.
 	 *
-	 * Note: This function generates dynamic swatch *descriptors* at startup so saves can resolve SwatchDesc references.
-	 * Swatch *recipes* are intentionally not generated here to avoid RecipeManager replication bloat; they are generated lazily for palette-defined swatches.
+* Note: This function will create a new swatch group if the given group ID doensn't exist in the SwatchGroupArray and call GenerateDynamicSwatchGroup -> GenerateDynamicSwatchDescriptor -> GenerateDynamicSwatchRecipe functions. This function does nothing if the swatch descriptor / recipe already exist.
 	 *
 	 * @param	UniqueGroupID				The swatch group ID to use. If the group doesn't exist it will be created.
 	 * @param	GroupDisplayName			The name to give to the swatch group. If the group already exist its name will be changed.

--- a/Source/UniversalSwatchSlots/Public/UniversalSwatchSlotsGIModule.h
+++ b/Source/UniversalSwatchSlots/Public/UniversalSwatchSlotsGIModule.h
@@ -54,7 +54,7 @@ class UNIVERSALSWATCHSLOTS_API UUniversalSwatchSlotsGIModule : public UGameInsta
 	/**
 	 * Create a new swatch using the desired group ID and swatch name.
 	 *
-* Note: This function will create a new swatch group if the given group ID doensn't exist in the SwatchGroupArray and call GenerateDynamicSwatchGroup -> GenerateDynamicSwatchDescriptor -> GenerateDynamicSwatchRecipe functions. This function does nothing if the swatch descriptor / recipe already exist.
+	 * Note: This function will create a new swatch group if the given group ID doensn't exist in the SwatchGroupArray and call GenerateDynamicSwatchGroup -> GenerateDynamicSwatchDescriptor -> GenerateDynamicSwatchRecipe functions. This function does nothing if the swatch descriptor / recipe already exist.
 	 *
 	 * @param	UniqueGroupID				The swatch group ID to use. If the group doesn't exist it will be created.
 	 * @param	GroupDisplayName			The name to give to the swatch group. If the group already exist its name will be changed.

--- a/Source/UniversalSwatchSlots/Public/UniversalSwatchSlotsGIModule.h
+++ b/Source/UniversalSwatchSlots/Public/UniversalSwatchSlotsGIModule.h
@@ -54,7 +54,8 @@ class UNIVERSALSWATCHSLOTS_API UUniversalSwatchSlotsGIModule : public UGameInsta
 	/**
 	 * Create a new swatch using the desired group ID and swatch name.
 	 *
-	 * Note: This function will create a new swatch group if the given group ID doensn't exist in the SwatchGroupArray and call GenerateDynamicSwatchGroup -> GenerateDynamicSwatchDescriptor functions. This function does nothing if the swatch descriptor already exist.
+	 * Note: This function generates dynamic swatch *descriptors* at startup so saves can resolve SwatchDesc references.
+	 * Swatch *recipes* are intentionally not generated here to avoid RecipeManager replication bloat; they are generated lazily for palette-defined swatches.
 	 *
 	 * @param	UniqueGroupID				The swatch group ID to use. If the group doesn't exist it will be created.
 	 * @param	GroupDisplayName			The name to give to the swatch group. If the group already exist its name will be changed.

--- a/Source/UniversalSwatchSlots/Public/UniversalSwatchSlotsSubsystem.h
+++ b/Source/UniversalSwatchSlots/Public/UniversalSwatchSlotsSubsystem.h
@@ -50,7 +50,7 @@ public:
 	/**
 	 * Create a new swatch using the desired group ID and swatch name.
 	 *
-	 * Note: This function will create a new swatch group if the given group ID doensn't exist in the SwatchGroupArray and call GenerateDynamicSwatchGroup -> GenerateDynamicSwatchDescriptor -> GenerateDynamicSwatchRecipe functions. This function does nothing if the swatch descriptor / recipe already exist.
+	 * Note: This function will create a new swatch group if the given group ID doensn't exist in the SwatchGroupArray and call GenerateDynamicSwatchGroup -> GenerateDynamicSwatchDescriptor. This function does nothing if the swatch descriptor already exist.
 	 *
 	 * @param	SwatchInformation			The swatch information to use.
 	 * @param	SwatchGroup					The used swatch group. NULL if the function was aborted.

--- a/Source/UniversalSwatchSlots/Public/UniversalSwatchSlotsSubsystem.h
+++ b/Source/UniversalSwatchSlots/Public/UniversalSwatchSlotsSubsystem.h
@@ -50,7 +50,8 @@ public:
 	/**
 	 * Create a new swatch using the desired group ID and swatch name.
 	 *
-	 * Note: This function will create a new swatch group if the given group ID doensn't exist in the SwatchGroupArray and call GenerateDynamicSwatchGroup -> GenerateDynamicSwatchDescriptor. This function does nothing if the swatch descriptor already exist.
+	 * Note: This function will create a new swatch group if the given group ID doensn't exist in the SwatchGroupArray and call GenerateDynamicSwatchGroup -> GenerateDynamicSwatchDescriptor -> GenerateDynamicSwatchRecipe.
+	 * Recipes are only generated for palette-defined swatches (not for every possible slot at startup) to avoid replication bloat.
 	 *
 	 * @param	SwatchInformation			The swatch information to use.
 	 * @param	SwatchGroup					The used swatch group. NULL if the function was aborted.

--- a/Source/UniversalSwatchSlots/Public/UniversalSwatchSlotsSubsystem.h
+++ b/Source/UniversalSwatchSlots/Public/UniversalSwatchSlotsSubsystem.h
@@ -50,8 +50,7 @@ public:
 	/**
 	 * Create a new swatch using the desired group ID and swatch name.
 	 *
-	 * Note: This function will create a new swatch group if the given group ID doensn't exist in the SwatchGroupArray and call GenerateDynamicSwatchGroup -> GenerateDynamicSwatchDescriptor -> GenerateDynamicSwatchRecipe.
-	 * Recipes are only generated for palette-defined swatches (not for every possible slot at startup) to avoid replication bloat.
+	 * Note: This function will create a new swatch group if the given group ID doensn't exist in the SwatchGroupArray and call GenerateDynamicSwatchGroup -> GenerateDynamicSwatchDescriptor -> GenerateDynamicSwatchRecipe functions. This function does nothing if the swatch descriptor / recipe already exist.
 	 *
 	 * @param	SwatchInformation			The swatch information to use.
 	 * @param	SwatchGroup					The used swatch group. NULL if the function was aborted.

--- a/UniversalSwatchSlots.uplugin
+++ b/UniversalSwatchSlots.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.2.0",
+	"VersionName": "1.2.1",
 	"FriendlyName": "Universal Swatch Slots",
 	"Description": "A mod that adds new swatches (one for each craftable item in the game) splitted into categories. These swatches comes with default colors depending on the item it corresponds to. You can create your own palette of swatches or modify existing ones in the mod configuration or directly by editing the JSON config file. It also means that you can easly share your palettes between different save game or even with others.",
 	"Category": "Modding",
@@ -25,10 +25,10 @@
 		{
 			"Name": "SML",
 			"Enabled": true,
-			"SemVersion": "^3.11.1"
+			"SemVersion": "^3.11.3"
 		}
 	],
-	"SemVersion": "1.2.0",
+	"SemVersion": "1.2.1",
 	"GameVersion": ">=416835",
 	"LocalizationTargets": [
 		{


### PR DESCRIPTION
Fixes #22 

Hi there, Sinds i had the issue i started looking at the mod and i think i fixed the issue with the relyable buffer overflow issue. It still seems to work fine in multiplayer and single player. I can't garantee that i didn't mis somthing with testing so please test it.

This pull request focuses on improving the reliability and efficiency of swatch slot generation and replication, as well as updating plugin metadata. The main changes prevent reliable buffer overflows during multiplayer replication by avoiding unnecessary recipe generation and excessive RPC calls, and ensure safer updates to color slots. Additionally, the plugin version and dependencies are updated.

Replication and reliability improvements:

* In `UUniversalSwatchSlotsGIModule::GenerateDynamicSwatchClasses`, removed the call to `GenerateDynamicSwatchRecipe` to avoid ReliableBufferOverflow issues during replication, as only descriptors are needed for save compatibility.
* In `AUniversalSwatchSlotsSubsystem::AddNewSwatchesColorSlotsToGameState`, added authority checks and early returns to prevent clients from making unnecessary updates, and restructured the logic to avoid repeated reliable RPC calls that could overflow the buffer. Updates to color slots are now only made if there are actual changes.

Swatch generation safety:

* In `AUniversalSwatchSlotsSubsystem::GenerateNewSwatchUsingInfo`, added a check to prevent overwriting existing swatches, and removed the unnecessary assignment of the return value from `GenerateDynamicSwatchRecipe`.
Plugin metadata updates:

* Updated `UniversalSwatchSlots.uplugin` to version 1.2.1 and bumped the required SML dependency version to ^3.11.3.